### PR TITLE
Add package.json description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "rescript-recoil",
   "version": "0.11.1",
+  "description": "Zero-cost bindings to Facebook's Recoil library",
   "scripts": {
     "build": "bsb -make-world",
     "start": "bsb -make-world -w",


### PR DESCRIPTION
We need that for a better presentation in the upcoming ReScript package index

Currently it looks like this:
![image](https://user-images.githubusercontent.com/1121889/102516608-5675e500-408f-11eb-9f54-5d3b196e0a55.png)

It's showing the first line of the README file, which is not ideal.