### PR TITLE
Add `atomWithDangerouslyAllowMutability` signatures

### DIFF
--- a/src/Recoil.resi
+++ b/src/Recoil.resi
@@ -34,6 +34,12 @@ type atomWithEffectsConfig<'value> = {
   effects_UNSTABLE: array<atomEffect<'value> => option<unit => unit>>,
 }
 
+type atomWithDangerouslyAllowMutabilityConfig<'value> = {
+  key: string,
+  default: 'value,
+  dangerouslyAllowMutability: bool,
+}
+
 type atomFamilyConfig<'parameter, 'value> = {
   key: string,
   default: 'parameter => 'value,
@@ -52,6 +58,12 @@ external atom: atomConfig<'value> => readWrite<'value> = "atom"
 
 @module("recoil")
 external atomWithEffects: atomWithEffectsConfig<'value> => readWrite<'value> = "atom"
+
+@module("recoil")
+external atomWithDangerouslyAllowMutability: atomWithDangerouslyAllowMutabilityConfig<
+  'value,
+> => readWrite<'value> = "atom"
+
 
 @module("recoil")
 external asyncAtom: atomConfig<Js.Promise.t<'value>> => readWrite<'value> = "atom"


### PR DESCRIPTION
# Context

Signatures in `Recoil.resi` interface file were missing for `Recoil.atomWithDangerouslyAllowMutability`

Related issues: #30 #24 
Related PRs: #29 

# What does this PR do?

It adds proper signatures to the interface file (`Recoil.res`)