### PR TITLE
Fix `atomWithEffectsFromRecoilValue` effect `onSet` params

### DIFF
--- a/src/Recoil.resi
+++ b/src/Recoil.resi
@@ -34,6 +34,12 @@ type atomWithEffectsConfig<'value> = {
   effects_UNSTABLE: array<atomEffect<'value> => option<unit => unit>>,
 }
 
+type atomWithEffectsFromRecoilValueConfig<'value, 'mode> = {
+  key: string,
+  default: t<'value, 'mode>,
+  effects_UNSTABLE: array<atomEffect<'value> => option<unit => unit>>,
+}
+
 type atomWithDangerouslyAllowMutabilityConfig<'value> = {
   key: string,
   default: 'value,
@@ -75,8 +81,10 @@ external asyncAtomWithEffects: atomWithEffectsConfig<'value> => readWrite<'value
 external atomFromRecoilValue: atomConfig<t<'value, _>> => readWrite<'value> = "atom"
 
 @module("recoil")
-external atomWithEffectsFromRecoilValue: atomWithEffectsConfig<t<'value, _>> => readWrite<'value> =
-  "atom"
+external atomWithEffectsFromRecoilValue: atomWithEffectsFromRecoilValueConfig<
+  'value,
+  _,
+> => readWrite<'value> = "atom"
 
 @module("recoil")
 external atomFamily: atomFamilyConfig<'parameter, 'value> => atomFamily<

--- a/src/Recoil__Atom.res
+++ b/src/Recoil__Atom.res
@@ -19,6 +19,12 @@ type atomWithEffectsConfig<'value> = {
   effects_UNSTABLE: array<atomEffect<'value> => option<unit => unit>>,
 }
 
+type atomWithEffectsFromRecoilValueConfig<'value, 'mode> = {
+  key: string,
+  default: Recoil__Value.t<'value, 'mode>,
+  effects_UNSTABLE: array<atomEffect<'value> => option<unit => unit>>,
+}
+
 type atomFamilyConfig<'parameter, 'value> = {
   key: string,
   default: 'parameter => 'value,
@@ -57,15 +63,15 @@ external atomFromRecoilValue: atomConfig<Recoil__Value.t<'value, _>> => Recoil__
 > = "atom"
 
 @module("recoil")
-external atomWithEffectsFromRecoilValue: atomWithEffectsConfig<
-  Recoil__Value.t<'value, _>,
+external atomWithEffectsFromRecoilValue: atomWithEffectsFromRecoilValueConfig<
+  'value,
+  _,
 > => Recoil__Value.readWrite<'value> = "atom"
 
 @module("recoil")
-external atomWithDangerouslyAllowMutability:
-  atomWithDangerouslyAllowMutabilityConfig<'value> =>
-  Recoil__Value.readWrite<'value> =
-  "atom";
+external atomWithDangerouslyAllowMutability: atomWithDangerouslyAllowMutabilityConfig<
+  'value,
+> => Recoil__Value.readWrite<'value> = "atom"
 
 @module("recoil")
 external atomFamily: atomFamilyConfig<'parameter, 'value> => atomFamily<


### PR DESCRIPTION
First of all, thanks for this library 🙏.

I noticed that the `~newValue` and `~oldValue` parameters of the `onSet` effect callback had the type `Recoil.t<'value>` instead of `'value` when using the `FromRecoilValue` function.